### PR TITLE
feat(regions): order regions alphabetically in output

### DIFF
--- a/src/Compiler/Collector/RegionsCollector.cs
+++ b/src/Compiler/Collector/RegionsCollector.cs
@@ -18,7 +18,7 @@ namespace Compiler.Collector
 
         public IEnumerable<ICompilableElementProvider> GetCompilableElements()
         {
-            return this.sectorElements.Regions.OrderBy(region => this.repository.GetForDefinitionFile(region.GetDefinition()));
+            return this.sectorElements.Regions.OrderBy(region => region.Name);
         }
     }
 }

--- a/tests/CompilerTest/Bogus/Factory/RegionFactory.cs
+++ b/tests/CompilerTest/Bogus/Factory/RegionFactory.cs
@@ -10,22 +10,24 @@ namespace CompilerTest.Bogus.Factory
         public static Region Make(
             string colour = null,
             List<Point> points = null,
-            Definition definition = null
+            Definition definition = null,
+            string name = null
         )
         {
-            return GetGenerator(colour, points, definition).Generate();
+            return GetGenerator(colour, points, definition, name).Generate();
         }
 
         private static Faker<Region> GetGenerator(
             string colour = null,
             List<Point> points = null,
-            Definition definition = null
+            Definition definition = null,
+            string name = null
         )
         {
             return new Faker<Region>()
                 .CustomInstantiator(
-                    _ => new Region(
-                        "REGION TEST",
+                    faker => new Region(
+                        name ?? faker.Random.Word(),
                         points == null ? RegionPointFactory.MakeList(2, colour) : points.Select(p => RegionPointFactory.Make(colour, p)).ToList(),
                         definition ?? DefinitionFactory.Make(),
                         DocblockFactory.Make(),

--- a/tests/CompilerTest/Collector/RegionsCollectorTest.cs
+++ b/tests/CompilerTest/Collector/RegionsCollectorTest.cs
@@ -11,14 +11,9 @@ namespace CompilerTest.Collector
         [Fact]
         public void TestItReturnsElementsInOrder()
         {
-            OutputGroup group1 = new("1");
-            OutputGroup group2 = new("2");
-            outputGroups.AddGroupWithFiles(group1, new List<string>{"foo.txt"});
-            outputGroups.AddGroupWithFiles(group2, new List<string>{"goo.txt"});
-
-            Region first = RegionFactory.Make(definition: DefinitionFactory.Make("foo.txt"));
-            Region second = RegionFactory.Make(definition: DefinitionFactory.Make("goo.txt"));
-            Region third = RegionFactory.Make(definition: DefinitionFactory.Make("foo.txt"));
+            Region first = RegionFactory.Make(name: "Manchester");
+            Region second = RegionFactory.Make(name: "Bristol");
+            Region third = RegionFactory.Make(name: "London City");
 
             sectorElements.Add(first);
             sectorElements.Add(second);
@@ -26,9 +21,9 @@ namespace CompilerTest.Collector
 
             IEnumerable<ICompilableElementProvider> expected = new List<ICompilableElementProvider>()
             {
-                first,
+                second,
                 third,
-                second
+                first
             };
             AssertCollectedItems(expected);
         }


### PR DESCRIPTION
So they appear in a nicer order in the ES list

fix #152