### PR TITLE
fix(includes): iterate airports by rule, then by airport

### DIFF
--- a/src/Compiler/Parser/DataParserFactory.cs
+++ b/src/Compiler/Parser/DataParserFactory.cs
@@ -18,11 +18,6 @@ namespace Compiler.Parser
 
         public ISectorDataParser GetParserForFile(AbstractSectorDataFile file)
         {
-            if (file.DataType == InputDataType.ESE_OWNERSHIP)
-            {
-                string filename = file.FullPath;
-                bool test = true;
-            }
             return file.DataType switch
             {
                 InputDataType.SCT_COLOUR_DEFINITIONS => new ColourParser(sectorElements, logger),
@@ -32,7 +27,7 @@ namespace Compiler.Parser
                     new FrequencyParser(108, 117, 50),
                     sectorElements,
                     logger
-                    ),
+                ),
                 InputDataType.SCT_NDBS => new NdbParser(new FrequencyParser(108, 950, 500), sectorElements, logger),
                 InputDataType.SCT_ARTCC => new ArtccParser(ArtccType.REGULAR, sectorElements, logger),
                 InputDataType.SCT_ARTCC_LOW => new ArtccParser(ArtccType.LOW, sectorElements, logger),

--- a/src/Compiler/Parser/DataParserFactory.cs
+++ b/src/Compiler/Parser/DataParserFactory.cs
@@ -18,6 +18,11 @@ namespace Compiler.Parser
 
         public ISectorDataParser GetParserForFile(AbstractSectorDataFile file)
         {
+            if (file.DataType == InputDataType.ESE_OWNERSHIP)
+            {
+                string filename = file.FullPath;
+                bool test = true;
+            }
             return file.DataType switch
             {
                 InputDataType.SCT_COLOUR_DEFINITIONS => new ColourParser(sectorElements, logger),

--- a/tests/CompilerTest/Config/ConfigIncludeLoaderTest.cs
+++ b/tests/CompilerTest/Config/ConfigIncludeLoaderTest.cs
@@ -26,30 +26,52 @@ namespace CompilerTest.Config
             fileLoader = ConfigIncludeLoaderFactory.Make(new CompilerArguments());
             includes = new ConfigInclusionRules();
         }
-        
+
         [Theory]
-        [InlineData("_TestData/ConfigIncludeLoader/AirportNotObject/config.json", "Invalid airport config in _TestData/ConfigIncludeLoader/AirportNotObject/config.json must be an object")]
-        [InlineData("_TestData/ConfigIncludeLoader/AirportKeyNotObject/config.json", "Invalid airport config[Airports] in _TestData/ConfigIncludeLoader/AirportKeyNotObject/config.json must be an object")]
-        [InlineData("_TestData/ConfigIncludeLoader/InvalidTypeType/config.json", "Invalid type field for section misc.regions - must be \"files\" or \"folders\"")]
-        [InlineData("_TestData/ConfigIncludeLoader/InvalidType/config.json", "Invalid type field for section misc.regions - must be \"files\" or \"folders\"")]
-        [InlineData("_TestData/ConfigIncludeLoader/NoFolder/config.json", "Folder invalid in section enroute.ownership - must be string under key \"folder\"")]
-        [InlineData("_TestData/ConfigIncludeLoader/FolderInvalid/config.json", "Folder invalid in section enroute.ownership - must be string under key \"folder\"")]
-        [InlineData("_TestData/ConfigIncludeLoader/RecursiveInvalid/config.json", "Recursive must be a boolean in section enroute.ownership")]
-        [InlineData("_TestData/ConfigIncludeLoader/IncludeAndExclude/config.json", "Cannot specify both include and exclude for folders in section enroute.ownership")]
-        [InlineData("_TestData/ConfigIncludeLoader/ExcludeNotAnArray/config.json", "Exclude list must be an array in section enroute.ownership")]
-        [InlineData("_TestData/ConfigIncludeLoader/ExcludeFilesNotAString/config.json", "Exclude file must be a string in section enroute.ownership")]
-        [InlineData("_TestData/ConfigIncludeLoader/IncludeNotAnArray/config.json", "Include list must be an array in section enroute.ownership")]
-        [InlineData("_TestData/ConfigIncludeLoader/IncludeFilesNotAString/config.json", "Include file must be a string in section enroute.ownership")]
-        [InlineData("_TestData/ConfigIncludeLoader/FilesListNotAnArray/config.json", "Files list invalid in section misc.regions - must be array under key \"files\"")]
-        [InlineData("_TestData/ConfigIncludeLoader/FilesListMissing/config.json", "Files list invalid in section misc.regions - must be array under key \"files\"")]
-        [InlineData("_TestData/ConfigIncludeLoader/IgnoreMissingNotBoolean/config.json", "Invalid ignore_missing value in section misc.regions - must be a boolean")]
-        [InlineData("_TestData/ConfigIncludeLoader/ExceptWhereExistsNotString/config.json", "Invalid except_where_exists value in section misc.regions - must be a string")]
-        [InlineData("_TestData/ConfigIncludeLoader/FilePathInvalid/config.json", "Invalid file path in section misc.regions - must be a string")]
-        [InlineData("_TestData/ConfigIncludeLoader/ParentSectionNotArrayOrObject/config.json", "Invalid config section for enroute - must be an object or array of objects") ]
-        [InlineData("_TestData/ConfigIncludeLoader/ParentSectionNotArrayOfObjects/config.json", "Invalid config section for enroute - must be an object or array of objects")]
-        [InlineData("_TestData/ConfigIncludeLoader/PatternNotAString/config.json", "Pattern invalid in section enroute.ownership - must be a regular expression string")]
-        [InlineData("_TestData/ConfigIncludeLoader/ExcludeDirectoryNotAnArray/config.json", "Invalid exclude_directory invalid in section misc.regions - must be an array of strings")]
-        [InlineData("_TestData/ConfigIncludeLoader/ExcludeDirectoryContainsNonString/config.json", "Invalid exclude_directory invalid in section misc.regions - must be an array of strings")]
+        [InlineData("_TestData/ConfigIncludeLoader/AirportNotObject/config.json",
+            "Invalid airport config in _TestData/ConfigIncludeLoader/AirportNotObject/config.json must be an object")]
+        [InlineData("_TestData/ConfigIncludeLoader/AirportKeyNotObject/config.json",
+            "Invalid airport config[Airports] in _TestData/ConfigIncludeLoader/AirportKeyNotObject/config.json must be an object")]
+        [InlineData("_TestData/ConfigIncludeLoader/InvalidTypeType/config.json",
+            "Invalid type field for section misc.regions - must be \"files\" or \"folders\"")]
+        [InlineData("_TestData/ConfigIncludeLoader/InvalidType/config.json",
+            "Invalid type field for section misc.regions - must be \"files\" or \"folders\"")]
+        [InlineData("_TestData/ConfigIncludeLoader/NoFolder/config.json",
+            "Folder invalid in section enroute.ownership - must be string under key \"folder\"")]
+        [InlineData("_TestData/ConfigIncludeLoader/FolderInvalid/config.json",
+            "Folder invalid in section enroute.ownership - must be string under key \"folder\"")]
+        [InlineData("_TestData/ConfigIncludeLoader/RecursiveInvalid/config.json",
+            "Recursive must be a boolean in section enroute.ownership")]
+        [InlineData("_TestData/ConfigIncludeLoader/IncludeAndExclude/config.json",
+            "Cannot specify both include and exclude for folders in section enroute.ownership")]
+        [InlineData("_TestData/ConfigIncludeLoader/ExcludeNotAnArray/config.json",
+            "Exclude list must be an array in section enroute.ownership")]
+        [InlineData("_TestData/ConfigIncludeLoader/ExcludeFilesNotAString/config.json",
+            "Exclude file must be a string in section enroute.ownership")]
+        [InlineData("_TestData/ConfigIncludeLoader/IncludeNotAnArray/config.json",
+            "Include list must be an array in section enroute.ownership")]
+        [InlineData("_TestData/ConfigIncludeLoader/IncludeFilesNotAString/config.json",
+            "Include file must be a string in section enroute.ownership")]
+        [InlineData("_TestData/ConfigIncludeLoader/FilesListNotAnArray/config.json",
+            "Files list invalid in section misc.regions - must be array under key \"files\"")]
+        [InlineData("_TestData/ConfigIncludeLoader/FilesListMissing/config.json",
+            "Files list invalid in section misc.regions - must be array under key \"files\"")]
+        [InlineData("_TestData/ConfigIncludeLoader/IgnoreMissingNotBoolean/config.json",
+            "Invalid ignore_missing value in section misc.regions - must be a boolean")]
+        [InlineData("_TestData/ConfigIncludeLoader/ExceptWhereExistsNotString/config.json",
+            "Invalid except_where_exists value in section misc.regions - must be a string")]
+        [InlineData("_TestData/ConfigIncludeLoader/FilePathInvalid/config.json",
+            "Invalid file path in section misc.regions - must be a string")]
+        [InlineData("_TestData/ConfigIncludeLoader/ParentSectionNotArrayOrObject/config.json",
+            "Invalid config section for enroute - must be an object or array of objects")]
+        [InlineData("_TestData/ConfigIncludeLoader/ParentSectionNotArrayOfObjects/config.json",
+            "Invalid config section for enroute - must be an object or array of objects")]
+        [InlineData("_TestData/ConfigIncludeLoader/PatternNotAString/config.json",
+            "Pattern invalid in section enroute.ownership - must be a regular expression string")]
+        [InlineData("_TestData/ConfigIncludeLoader/ExcludeDirectoryNotAnArray/config.json",
+            "Invalid exclude_directory invalid in section misc.regions - must be an array of strings")]
+        [InlineData("_TestData/ConfigIncludeLoader/ExcludeDirectoryContainsNonString/config.json",
+            "Invalid exclude_directory invalid in section misc.regions - must be an array of strings")]
         public void TestItThrowsExceptionOnBadData(string fileToLoad, string expectedMessage)
         {
             ConfigFileInvalidException exception = Assert.Throws<ConfigFileInvalidException>(
@@ -87,7 +109,7 @@ namespace CompilerTest.Config
             Assert.Equal(6, ruleList.Count);
 
             // Airport - Basic
-            InclusionRule airportBasicRule = (InclusionRule) ruleList[0];
+            InclusionRule airportBasicRule = (InclusionRule)ruleList[0];
             Assert.IsType<FileListGenerator>(airportBasicRule.ListGenerator);
             Assert.Equal(2, airportBasicRule.ListGenerator.GetPaths().Count());
             Assert.Equal(
@@ -99,18 +121,22 @@ namespace CompilerTest.Config
                 airportBasicRule.ListGenerator.GetPaths().ToList()
             );
             Assert.Contains(airportBasicRule.Validators, validator => validator.GetType() == typeof(FileExists));
-            Assert.DoesNotContain(airportBasicRule.Filters, fileFilter => fileFilter.GetType() == typeof(IgnoreWhenFileExists));
-            Assert.Contains(airportBasicRule.Filters, fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder));
+            Assert.DoesNotContain(airportBasicRule.Filters,
+                fileFilter => fileFilter.GetType() == typeof(IgnoreWhenFileExists));
+            Assert.Contains(airportBasicRule.Filters,
+                fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder));
             Assert.Contains(
                 "EGLL",
-                (airportBasicRule.Filters.First(fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder)) as ExcludeByParentFolder)?.ParentFolders
-                    ?? throw new InvalidOperationException()
+                (airportBasicRule.Filters.First(fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder)) as
+                    ExcludeByParentFolder)?.ParentFolders
+                ?? throw new InvalidOperationException()
             );
             Assert.Equal(InputDataType.SCT_AIRPORT_BASIC, airportBasicRule.DataType);
-            Assert.Equal(new OutputGroup("airport.SCT_AIRPORT_BASIC.EGLL", "Start EGLL Basic"), airportBasicRule.GetOutputGroup());
-            
+            Assert.Equal(new OutputGroup("airport.SCT_AIRPORT_BASIC.EGLL", "Start EGLL Basic"),
+                airportBasicRule.GetOutputGroup());
+
             // Airport - Geo
-            InclusionRule airportGeoRule = (InclusionRule) ruleList[1];
+            InclusionRule airportGeoRule = (InclusionRule)ruleList[1];
             Assert.IsType<FileListGenerator>(airportGeoRule.ListGenerator);
             Assert.Single(airportGeoRule.ListGenerator.GetPaths());
             Assert.Equal(
@@ -124,26 +150,29 @@ namespace CompilerTest.Config
             Assert.Contains(airportGeoRule.Filters, validator => validator.GetType() == typeof(IgnoreWhenFileExists));
             Assert.Equal(
                 GetFullFilePath("_TestData/ConfigIncludeLoader/ValidConfig/Airports/EGLL/SMR/Foo.txt"),
-                (airportGeoRule.Filters.Where(validator => validator.GetType() == typeof(IgnoreWhenFileExists)).FirstOrDefault() as IgnoreWhenFileExists)?.FileToCheckAgainst
+                (airportGeoRule.Filters.Where(validator => validator.GetType() == typeof(IgnoreWhenFileExists))
+                    .FirstOrDefault() as IgnoreWhenFileExists)?.FileToCheckAgainst
             );
             Assert.Equal(InputDataType.SCT_GEO, airportGeoRule.DataType);
             Assert.Equal(new OutputGroup("airport.SCT_GEO.EGLL", "Start EGLL Geo"), airportGeoRule.GetOutputGroup());
-            
+
             // Enroute ownership folder 1
-            InclusionRule ownershipRule1 = (InclusionRule) ruleList[2];
+            InclusionRule ownershipRule1 = (InclusionRule)ruleList[2];
             Assert.Equal(
-                new List<string>{GetFullFilePath("_TestData/ConfigIncludeLoader/ValidConfig/Ownership/Alternate/Foo.txt")},
+                new List<string>
+                    { GetFullFilePath("_TestData/ConfigIncludeLoader/ValidConfig/Ownership/Alternate/Foo.txt") },
                 ownershipRule1.ListGenerator.GetPaths().ToList()
             );
             Assert.IsType<RecursiveFolderFileListGenerator>(ownershipRule1.ListGenerator);
             Assert.Empty(ownershipRule1.Filters);
             Assert.Empty(ownershipRule1.Validators);
-            Assert.Equal(new OutputGroup("enroute.ESE_OWNERSHIP", "Start enroute Ownership"), ownershipRule1.GetOutputGroup());
-            
+            Assert.Equal(new OutputGroup("enroute.ESE_OWNERSHIP", "Start enroute Ownership"),
+                ownershipRule1.GetOutputGroup());
+
             // Enroute ownership folder 2
-            InclusionRule ownershipRule2 = (InclusionRule) ruleList[3];
+            InclusionRule ownershipRule2 = (InclusionRule)ruleList[3];
             Assert.Equal(
-                new List<string>{GetFullFilePath("_TestData/ConfigIncludeLoader/ValidConfig/Ownership/Foo/Foo.txt")},
+                new List<string> { GetFullFilePath("_TestData/ConfigIncludeLoader/ValidConfig/Ownership/Foo/Foo.txt") },
                 ownershipRule2.ListGenerator.GetPaths().ToList()
             );
             Assert.IsType<FolderFileListGenerator>(ownershipRule2.ListGenerator);
@@ -153,12 +182,14 @@ namespace CompilerTest.Config
             ) as IncludeFileFilter ?? throw new InvalidOperationException();
             Assert.Single(filter.FileNames);
             Assert.Equal("Foo.txt", filter.FileNames.First());
-            Assert.Equal(new OutputGroup("enroute.ESE_OWNERSHIP", "Start enroute Ownership"), ownershipRule2.GetOutputGroup());
-            
+            Assert.Equal(new OutputGroup("enroute.ESE_OWNERSHIP", "Start enroute Ownership"),
+                ownershipRule2.GetOutputGroup());
+
             // Enroute ownership folder 3
-            InclusionRule ownershipRule3 = (InclusionRule) ruleList[4];
+            InclusionRule ownershipRule3 = (InclusionRule)ruleList[4];
             Assert.Equal(
-                new List<string>{GetFullFilePath("_TestData/ConfigIncludeLoader/ValidConfig/Ownership/Non-UK/EUR Islands.txt")},
+                new List<string>
+                    { GetFullFilePath("_TestData/ConfigIncludeLoader/ValidConfig/Ownership/Non-UK/EUR Islands.txt") },
                 ownershipRule3.ListGenerator.GetPaths().ToList()
             );
             Assert.IsType<FolderFileListGenerator>(ownershipRule3.ListGenerator);
@@ -168,16 +199,17 @@ namespace CompilerTest.Config
             ) as ExcludeFileFilter ?? throw new InvalidOperationException();
             Assert.Single(excludeFileFilter.FileNames);
             Assert.Equal("EUR Islands.txt", excludeFileFilter.FileNames.First());
-            
+
             Assert.Contains(ownershipRule3.Filters, fileFilter => fileFilter.GetType() == typeof(FilePatternFilter));
             var patternFilter = ownershipRule3.Filters.First(
                 fileFilter => fileFilter.GetType() == typeof(FilePatternFilter)
             ) as FilePatternFilter ?? throw new InvalidOperationException();
             Assert.Equal(".*?", patternFilter.Pattern.ToString());
-            Assert.Equal(new OutputGroup("enroute.ESE_OWNERSHIP", "Start enroute Ownership"), ownershipRule3.GetOutputGroup());
-            
+            Assert.Equal(new OutputGroup("enroute.ESE_OWNERSHIP", "Start enroute Ownership"),
+                ownershipRule3.GetOutputGroup());
+
             // Misc regions
-            InclusionRule miscRegions = (InclusionRule) ruleList[5];
+            InclusionRule miscRegions = (InclusionRule)ruleList[5];
             Assert.IsType<FileListGenerator>(miscRegions.ListGenerator);
             Assert.Equal(3, miscRegions.ListGenerator.GetPaths().Count());
             Assert.Equal(
@@ -190,9 +222,88 @@ namespace CompilerTest.Config
                 miscRegions.ListGenerator.GetPaths().ToList()
             );
             Assert.Contains(airportBasicRule.Validators, validator => validator.GetType() == typeof(FileExists));
-            Assert.DoesNotContain(airportBasicRule.Filters, validator => validator.GetType() == typeof(IgnoreWhenFileExists));
+            Assert.DoesNotContain(airportBasicRule.Filters,
+                validator => validator.GetType() == typeof(IgnoreWhenFileExists));
             Assert.Equal(InputDataType.SCT_AIRPORT_BASIC, airportBasicRule.DataType);
-            Assert.Equal(new OutputGroup("airport.SCT_AIRPORT_BASIC.EGLL", "Start EGLL Basic"), airportBasicRule.GetOutputGroup());
+            Assert.Equal(new OutputGroup("airport.SCT_AIRPORT_BASIC.EGLL", "Start EGLL Basic"),
+                airportBasicRule.GetOutputGroup());
+        }
+
+        [Fact]
+        public void TestItLoadsAirportConfigInRuleOrder()
+        {
+            fileLoader.LoadConfig(
+                includes,
+                JObject.Parse(File.ReadAllText("_TestData/ConfigIncludeLoader/AirportOrder/config.json")),
+                "_TestData/ConfigIncludeLoader/AirportOrder/config.json"
+            );
+
+            List<IInclusionRule> ruleList = includes.ToList();
+            Assert.Equal(4, ruleList.Count);
+
+            // Airport - Basic, first rule for EGKK
+            InclusionRule gatwickFirstRule = (InclusionRule)ruleList[0];
+            Assert.Equal(
+                new List<string>
+                {
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGKK/Basic.txt"),
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGKK/Basic2.txt"),
+                },
+                gatwickFirstRule.ListGenerator.GetPaths().ToList()
+            );
+            Assert.Contains(gatwickFirstRule.Filters,
+                fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder));
+            Assert.Contains(
+                "EGKK",
+                (gatwickFirstRule.Filters.First(
+                    fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder)) as ExcludeByParentFolder)
+                ?.ParentFolders
+                ?? throw new InvalidOperationException()
+            );
+
+            // Airport - Basic, first rule for EGLL
+            InclusionRule heathrowFirstRule = (InclusionRule)ruleList[1];
+            Assert.Equal(
+                new List<string>
+                {
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGLL/Basic.txt"),
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGLL/Basic2.txt"),
+                },
+                heathrowFirstRule.ListGenerator.GetPaths().ToList()
+            );
+            Assert.Contains(heathrowFirstRule.Filters,
+                fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder));
+            Assert.Contains(
+                "EGKK",
+                (heathrowFirstRule.Filters.First(
+                    fileFilter => fileFilter.GetType() == typeof(ExcludeByParentFolder)) as ExcludeByParentFolder)
+                ?.ParentFolders
+                ?? throw new InvalidOperationException()
+            );
+
+            // Airport - Basic, second rule for EGKK
+            InclusionRule gatwickSecondRule = (InclusionRule)ruleList[2];
+            Assert.Equal(
+                new List<string>
+                {
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGKK/Basic.txt"),
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGKK/Basic2.txt"),
+                },
+                gatwickSecondRule.ListGenerator.GetPaths().ToList()
+            );
+            Assert.Empty(gatwickSecondRule.Filters);
+
+            // Airport - Basic, second rule for EGLL
+            InclusionRule heathrowSecondRule = (InclusionRule)ruleList[3];
+            Assert.Equal(
+                new List<string>
+                {
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGLL/Basic.txt"),
+                    GetFullFilePath("_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGLL/Basic2.txt"),
+                },
+                heathrowSecondRule.ListGenerator.GetPaths().ToList()
+            );
+            Assert.Empty(heathrowSecondRule.Filters);
         }
     }
 }

--- a/tests/CompilerTest/_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGKK/.gitignore
+++ b/tests/CompilerTest/_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGKK/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/CompilerTest/_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGLL/.gitignore
+++ b/tests/CompilerTest/_TestData/ConfigIncludeLoader/AirportOrder/Airports/EGLL/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/CompilerTest/_TestData/ConfigIncludeLoader/AirportOrder/config.json
+++ b/tests/CompilerTest/_TestData/ConfigIncludeLoader/AirportOrder/config.json
@@ -1,0 +1,29 @@
+{
+  "includes": {
+    "airports": {
+      "Airports": {
+        "basic": [
+          {
+            "type": "files",
+            "files": [
+              "Basic.txt",
+              "Basic2.txt"
+            ],
+            "exclude_directory": [
+              "EGKK"
+            ]
+          },
+          {
+            "type": "files",
+            "files": [
+              "Basic.txt",
+              "Basic2.txt"
+            ]
+          }
+        ]
+      }
+    },
+    "enroute": {},
+    "misc": {}
+  }
+}


### PR DESCRIPTION
Currently, we iterate each of the airport directories and within that, iterate through the rules.
This has the effect of making the ordering of the rules essentially useless, as all the rules get
applied to the current airport before moving on. This change modifies the processing order so it
applies each rule in turn to each folder, which produces the desired effect.

fix #167