### PR TITLE
Change sytax error line number formating

### DIFF
--- a/src/Compiler/Error/SyntaxError.cs
+++ b/src/Compiler/Error/SyntaxError.cs
@@ -27,7 +27,7 @@ namespace Compiler.Error
 
         public string GetMessage()
         {
-            return $"Syntax Error: {this.problem} in {this.definition.Filename} at line {this.definition.LineNumber}";
+            return $"Syntax Error: {this.problem} at {this.definition.Filename}:{this.definition.LineNumber}";
         }
 
         public bool IsFatal()

--- a/src/Compiler/Error/ValidationRuleFailure.cs
+++ b/src/Compiler/Error/ValidationRuleFailure.cs
@@ -16,7 +16,8 @@ namespace Compiler.Error
 
         public string GetMessage()
         {
-            return $"Validation rule not met: {error}, defined in {definable.GetDefinition()}";
+            Definition definition = definable.GetDefinition();
+            return $"Validation rule not met: {error}, defined at {definition.Filename}:{definition.LineNumber}";
         }
 
         public bool IsFatal()


### PR DESCRIPTION
Currently, the output of a `SyntaxError` in the console is `in {file} at {line}`, this PR will change it to `at {file}:{line}`.

The reason being that this allows for the path opened directly in various text editors directly at the given line as oppose to the current implementation which will just open the file and the user has to find the line themselves